### PR TITLE
TRITON-2378 Update sshkpk, sshpk-agent, and http-signature 

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
         "bunyan": "1.8.12",
         "clone": "0.1.5",
         "dashdash": "1.10.1",
-        "http-signature": "https://github.com/TritonDataCenter/node-http-signature.git#5d8dc05d4e0ec3421bbf40b35be5a30152749638",
+        "http-signature": "https://github.com/TritonDataCenter/node-http-signature.git#a08360e",
         "once": "1.3.0",
         "sshpk-agent": "^1.8.1",
-        "sshpk": "^1.17.0",
+        "sshpk": "^1.18.0",
         "vasync": "^2.2.1"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "smartdc-auth",
     "description": "Triton Authentication Library",
-    "version": "2.5.9",
+    "version": "2.6.0",
     "author": "MNX Cloud (mnx.io)",
     "license": "MIT",
     "contributors": [
@@ -32,10 +32,10 @@
         "bunyan": "1.8.12",
         "clone": "0.1.5",
         "dashdash": "1.10.1",
-        "http-signature": "^1.0.2",
+        "http-signature": "^1.3.6",
         "once": "1.3.0",
-        "sshpk-agent": "^1.3.0",
-        "sshpk": "^1.13.2",
+        "sshpk-agent": "^1.8.1",
+        "sshpk": "^1.17.0",
         "vasync": "^2.2.1"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "bunyan": "1.8.12",
         "clone": "0.1.5",
         "dashdash": "1.10.1",
-        "http-signature": "^1.3.6",
+        "http-signature": "https://github.com/TritonDataCenter/node-http-signature.git#5d8dc05d4e0ec3421bbf40b35be5a30152749638",
         "once": "1.3.0",
         "sshpk-agent": "^1.8.1",
         "sshpk": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "bunyan": "1.8.12",
         "clone": "0.1.5",
         "dashdash": "1.10.1",
-        "http-signature": "https://github.com/TritonDataCenter/node-http-signature.git#a08360e",
+        "http-signature": "1.4.0",
         "once": "1.3.0",
         "sshpk-agent": "^1.8.1",
         "sshpk": "^1.18.0",


### PR DESCRIPTION
These updates bring in support for ED25519 keys

## Testing Notes
- Confirmed that `make check test` succeeded.
- Pulled the relevant [http-signature changes](https://github.com/TritonDataCenter/node-http-signature/pull/132) into [cloudapi](https://github.com/TritonDataCenter/sdc-cloudapi/compare/master...TRITON-2378) and confirmed that  `make check` succeeded and that I could install the changes via `sdcadm update -C experimental cloudapi@TRITON-2378-20231116T192012Z-g4220b98`
- Updated sshpk in [sdc-ufds](https://github.com/TritonDataCenter/sdc-ufds/compare/TRITON-2378) and confirmed that `make check` succeeded and that I could install the changes via `sdcadm update -C experimental ufds@TRITON-2378-20231116T205537Z-g5fb2ee0`
- Finally, I pulled these changes into [node-triton](https://github.com/TritonDataCenter/node-triton/compare/TRITON-2378), removed all keys from my account except for an ED25519 key and confirmed that I could make Cloud API requests and provision an instance.